### PR TITLE
add NewTimer and After methods to Clock

### DIFF
--- a/clock_test.go
+++ b/clock_test.go
@@ -291,17 +291,6 @@ func TestFakeTimerStopStopsOldSends(t *testing.T) {
 	}
 }
 
-func TestRealClock(t *testing.T) {
-	// for coverage
-	clk := Default()
-	clk.Now()
-	clk.Sleep(1 * time.Nanosecond)
-	clk.After(1 * time.Nanosecond)
-	tt := clk.NewTimer(1 * time.Nanosecond)
-	tt.Stop()
-	tt.Reset(1 * time.Nanosecond)
-}
-
 func TestFakeTimerResetStopsOldSends(t *testing.T) {
 	clk := NewFake()
 	tt := clk.NewTimer(1 * time.Second)
@@ -316,6 +305,17 @@ func TestFakeTimerResetStopsOldSends(t *testing.T) {
 	if t2 == nil {
 		t.Errorf("expected a send, got nothing")
 	}
+}
+
+func TestRealClock(t *testing.T) {
+	// for coverage
+	clk := Default()
+	clk.Now()
+	clk.Sleep(1 * time.Nanosecond)
+	clk.After(1 * time.Nanosecond)
+	tt := clk.NewTimer(1 * time.Nanosecond)
+	tt.Stop()
+	tt.Reset(1 * time.Nanosecond)
 }
 
 func waitFor(c <-chan time.Time) *time.Time {

--- a/clock_test.go
+++ b/clock_test.go
@@ -75,16 +75,16 @@ func TestFakeTimer(t *testing.T) {
 		timer := clk.NewTimer(1 * time.Hour)
 		go tc.f(clk)
 
-		select {
-		case <-time.After(2 * time.Second):
-			t.Fatalf("didn't receive time notification")
-		case recvVal := <-timer.C:
-			if !recvVal.Equal(tc.recvVal) {
-				t.Errorf("#%d, <-timer.C: want %s, got %s", i, tc.recvVal, recvVal)
-			}
-			if !clk.Now().Equal(tc.nowVal) {
-				t.Errorf("#%d, clk.Now: want %s, got %s", i, tc.nowVal, clk.Now())
-			}
+		recvVal := waitFor(timer.C)
+		if recvVal == nil {
+			t.Errorf("didn't receive time notification")
+			continue
+		}
+		if !recvVal.Equal(tc.recvVal) {
+			t.Errorf("#%d, <-timer.C: want %s, got %s", i, tc.recvVal, recvVal)
+		}
+		if !clk.Now().Equal(tc.nowVal) {
+			t.Errorf("#%d, clk.Now: want %s, got %s", i, tc.nowVal, clk.Now())
 		}
 	}
 }

--- a/clock_test.go
+++ b/clock_test.go
@@ -308,7 +308,6 @@ func TestFakeTimerResetStopsOldSends(t *testing.T) {
 }
 
 func TestRealClock(t *testing.T) {
-	// for coverage
 	clk := Default()
 	clk.Now()
 	clk.Sleep(1 * time.Nanosecond)

--- a/clock_test.go
+++ b/clock_test.go
@@ -121,7 +121,7 @@ func TestFakeTimerReset(t *testing.T) {
 		t.Errorf("first: want %s, got %s", oneSec, t1)
 	}
 
-	if immediatelySeeNothing(tt.C) != nil {
+	if immediatelyRecv(tt.C) != nil {
 		t.Fatal("second reset should never fire")
 	}
 }
@@ -285,7 +285,7 @@ func TestFakeTimerStopStopsOldSends(t *testing.T) {
 	tt := clk.NewTimer(1 * time.Second)
 	tt.Stop()
 	clk.Add(1 * time.Second)
-	t1 := immediatelySeeNothing(tt.C)
+	t1 := immediatelyRecv(tt.C)
 	if t1 != nil {
 		t.Errorf("expected no send, got %s", *t1)
 	}
@@ -307,7 +307,7 @@ func TestFakeTimerResetStopsOldSends(t *testing.T) {
 	tt := clk.NewTimer(1 * time.Second)
 	tt.Reset(2 * time.Second)
 	clk.Add(1 * time.Second)
-	t1 := immediatelySeeNothing(tt.C)
+	t1 := immediatelyRecv(tt.C)
 	if t1 != nil {
 		t.Errorf("expected no send, got %s", *t1)
 	}
@@ -327,7 +327,7 @@ func waitFor(c <-chan time.Time) *time.Time {
 	}
 }
 
-func immediatelySeeNothing(c <-chan time.Time) *time.Time {
+func immediatelyRecv(c <-chan time.Time) *time.Time {
 	select {
 	case ti := <-c:
 		return &ti

--- a/timer.go
+++ b/timer.go
@@ -27,7 +27,9 @@ type fakeTimer struct {
 	c      chan<- time.Time
 	clk    *fake
 	active bool
-	sends  []*send
+	// sends is where we store all the sends made by this timer so we can
+	// deactivate the old ones when Reset or Stop is called.
+	sends []*send
 }
 
 func (ft *fakeTimer) Reset(d time.Duration) bool {

--- a/timer.go
+++ b/timer.go
@@ -24,8 +24,13 @@ func (t *Timer) Stop() bool {
 }
 
 type fakeTimer struct {
-	c      chan<- time.Time
-	clk    *fake
+	// c is the same chan as C in the Timer that contains this fakeTimer
+	c chan<- time.Time
+	// clk is kept so we can maintain just one lock and to add and attempt to
+	// send the times made by this timer during Resets and Stops
+	clk *fake
+	// active is true until the fakeTimer's send is attempted or it has been
+	// stopped
 	active bool
 	// sends is where we store all the sends made by this timer so we can
 	// deactivate the old ones when Reset or Stop is called.

--- a/timer.go
+++ b/timer.go
@@ -1,0 +1,64 @@
+package clock
+
+import "time"
+
+type Timer struct {
+	C <-chan time.Time
+
+	timer     *time.Timer
+	fakeTimer *fakeTimer
+}
+
+func (t *Timer) Reset(d time.Duration) bool {
+	if t.timer != nil {
+		return t.timer.Reset(d)
+	}
+	return t.fakeTimer.Reset(d)
+}
+
+func (t *Timer) Stop() bool {
+	if t.timer != nil {
+		return t.timer.Stop()
+	}
+	return t.fakeTimer.Stop()
+}
+
+type fakeTimer struct {
+	c       chan<- time.Time
+	target  time.Time
+	clk     *fake
+	expired bool
+}
+
+func (ft *fakeTimer) Reset(d time.Duration) bool {
+	ft.clk.Lock()
+	defer ft.clk.Unlock()
+	ft.target = ft.clk.t.Add(d)
+	exp := ft.expired
+	ft.expired = false
+	ft.clk.sendTimes()
+	return exp
+}
+
+func (ft *fakeTimer) Stop() bool {
+	ft.clk.Lock()
+	defer ft.clk.Unlock()
+	exp := ft.expired
+	ft.expired = true
+	ft.clk.sendTimes()
+	return exp
+}
+
+type sortedFakeTimers []*fakeTimer
+
+func (s sortedFakeTimers) Len() int {
+	return len(s)
+}
+
+func (s sortedFakeTimers) Less(i, j int) bool {
+	return s[i].target.Before(s[j].target)
+}
+
+func (s sortedFakeTimers) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}

--- a/timer.go
+++ b/timer.go
@@ -36,8 +36,11 @@ func (ft *fakeTimer) Reset(d time.Duration) bool {
 	ft.target = ft.clk.t.Add(d)
 	exp := ft.expired
 	ft.expired = false
+	if !exp {
+		ft.clk.timers = append(ft.clk.timers, ft)
+	}
 	ft.clk.sendTimes()
-	return exp
+	return !exp
 }
 
 func (ft *fakeTimer) Stop() bool {

--- a/timer.go
+++ b/timer.go
@@ -24,32 +24,32 @@ func (t *Timer) Stop() bool {
 }
 
 type fakeTimer struct {
-	c       chan<- time.Time
-	target  time.Time
-	clk     *fake
-	expired bool
+	c      chan<- time.Time
+	target time.Time
+	clk    *fake
+	active bool
 }
 
 func (ft *fakeTimer) Reset(d time.Duration) bool {
 	ft.clk.Lock()
 	defer ft.clk.Unlock()
 	ft.target = ft.clk.t.Add(d)
-	exp := ft.expired
-	ft.expired = false
-	if !exp {
+	active := ft.active
+	ft.active = true
+	if !active { // FIXME
 		ft.clk.timers = append(ft.clk.timers, ft)
 	}
 	ft.clk.sendTimes()
-	return !exp
+	return active
 }
 
 func (ft *fakeTimer) Stop() bool {
 	ft.clk.Lock()
 	defer ft.clk.Unlock()
-	exp := ft.expired
-	ft.expired = true
+	active := ft.active
+	ft.active = false
 	ft.clk.sendTimes()
-	return exp
+	return active
 }
 
 type sortedFakeTimers []*fakeTimer


### PR DESCRIPTION
This allows for the testing of code that previously used `time.After` and `time.Timer`.

It correctly handles `Timer.Reset` and `Timer.Stop`. To do so, instead of using `time.Timer` directly, a wrapping `clock.Timer` struct is introduced. In the normal clock case, this wrapper sends all method calls to the `time.Timer` it contains and the channel `C` on it is the same as the underlying `time.Timer.C`.

In the testing case, the implementation uses the concepts of "sends" to model the Go runtime's ability to pass `time.Time` objects down the `C` channel. This must happen multiple times if the Timer was reset between changes to the fake Clock's time and is tricky to get right without the send concept. You can see the documentation on the `fakeTimer` and `send` structs for more.
