### PR TITLE
PR_AdingPowerSupport_golang-github-jmhodges-clock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,18 @@
 language: go
+arch:
+  - amd64
+  - ppc64le
 
 go:
   - 1.3
   - 1.4
   - 1.5
-
+jobs:
+ exclude:
+ exclude: # Excluding below jobs as "go" versions earlier than 1.5 are not supported for arch: ppc64le
+  - arch: ppc64le
+    go: 1.3
+  - arch: ppc64le
+    go: 1.4
+    
 sudo: false


### PR DESCRIPTION
Excluding "go" job versions earlier than 1.5 as these are not supported for arch: ppc64le.

Adding power support ppc64le.
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

Please find the Travis link where the build is successful for rest all: https://travis-ci.com/github/santosh653/clock

Please comment in the comment section if I am missing any other details or if you need any other details.

Thanks you !!